### PR TITLE
Added type assertions to get NewTypedParamValueUllong type

### DIFF
--- a/prometheus-libvirt-exporter.go
+++ b/prometheus-libvirt-exporter.go
@@ -368,18 +368,20 @@ func CollectDomain(ch chan<- prometheus.Metric, l *libvirt.Libvirt, domain domai
             for _, param := range vcpuStats {
                 switch param.Field {
                 case "vcpu_time":
+                    value := param.Value.(libvirt.NewTypedParamValueUllong)
                     ch <- prometheus.MustNewConstMetric(
                         libvirtDomainVcpuWaitDesc,
                         prometheus.CounterValue,
-                        float64(param.Value.U)/1e9,
+                        float64(value.Value)/1e9,
                         domain.domainName,
                         strconv.Itoa(i),
                     )
                 case "delay":
+                    value := param.Value.(libvirt.NewTypedParamValueUllong)
                     ch <- prometheus.MustNewConstMetric(
                         libvirtDomainVcpuDelayDesc,
                         prometheus.CounterValue,
-                        float64(param.Value.U)/1e9,
+                        float64(value.Value)/1e9,
                         domain.domainName,
                         strconv.Itoa(i),
                     )


### PR DESCRIPTION
Use Value field from the typed value struct
Keep the nanosecond to second conversion
Keep the rest of the function unchanged